### PR TITLE
etc: docker-compose yona-db 서비스 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 data
+yona-db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 
 services:
   yona:
@@ -12,3 +12,13 @@ services:
       - ./data:/yona/data
     ports:
       - "9000:9000"
+  yona-db:
+    image: mariadb:10.3
+    restart: always
+    environment:
+      - MARIADB_ROOT_PASSWORD=root1234
+      - MARIADB_USER=yona
+      - MARIADB_PASSWORD=pass1234
+      - MARIADB_DATABASE=yona
+    volumes:
+      - ./yona-db:/var/lib/mysql


### PR DESCRIPTION
- docker-compose version "3" 으로 변경
- docker-compose yona-db 서비스 추가
    - 별도의 Maria DB설치 없이, docker-compose에 포함됨
    - yona 컨테이너 내에서만 접속 가능 